### PR TITLE
챌린지 등록 - 지난 챌린지 평가

### DIFF
--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/AddChallengeActivity.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/AddChallengeActivity.kt
@@ -1,12 +1,30 @@
 package com.hrhn.presentation.ui.screen.addchallenge
 
-import androidx.appcompat.app.AppCompatActivity
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
 import com.hrhn.R
+import com.hrhn.databinding.ActivityAddChanllengeBinding
+import com.hrhn.presentation.ui.screen.addchallenge.check.CheckChallengeFragment
 
 class AddChallengeActivity : AppCompatActivity() {
+    private val binding by lazy { ActivityAddChanllengeBinding.inflate(layoutInflater) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_add_chanllenge)
+        setContentView(binding.root)
+
+        // TODO last 아이템이 평가가 안되어있는지 체크
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                add(R.id.fcv_add_challenge, CheckChallengeFragment())
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context) = Intent(context, AddChallengeActivity::class.java)
     }
 }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/Emoji.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/Emoji.kt
@@ -1,0 +1,16 @@
+package com.hrhn.presentation.ui.screen.addchallenge
+
+data class Emoji(
+    val isChecked: Boolean = false,
+    val label: String,
+    val color: String
+)
+
+fun getEmojis() = listOf(
+    Emoji(label = ":D", color = "#FFBBAC"),
+    Emoji(label = ":3", color = "#FED977"),
+    Emoji(label = ":P", color = "#ACDE80"),
+    Emoji(label = ":/", color = "#B0D9FF"),
+    Emoji(label = ":(", color = "#97B4FE"),
+    Emoji(label = ":'(", color = "#E1BAFF")
+)

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
@@ -1,16 +1,14 @@
-package com.hrhn.presentation.ui.screen.main.today
+package com.hrhn.presentation.ui.screen.addchallenge.add
 
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.hrhn.databinding.FragmentTodayBinding
-import com.hrhn.presentation.ui.screen.addchallenge.AddChallengeActivity
-import java.time.LocalDateTime
+import com.hrhn.databinding.FragmentAddChallengeBinding
 
-class TodayFragment : Fragment() {
-    private var _binding: FragmentTodayBinding? = null
+class AddChallengeFragment : Fragment() {
+    private var _binding: FragmentAddChallengeBinding? = null
     private val binding get() = requireNotNull(_binding)
 
     override fun onCreateView(
@@ -18,16 +16,12 @@ class TodayFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentTodayBinding.inflate(inflater)
+        _binding = FragmentAddChallengeBinding.inflate(layoutInflater)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.today = LocalDateTime.now()
-        binding.btnAddChallenge.setOnClickListener {
-            startActivity(AddChallengeActivity.newIntent(requireContext()))
-        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckChallengeFragment.kt
@@ -1,0 +1,43 @@
+package com.hrhn.presentation.ui.screen.addchallenge.check
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.hrhn.databinding.FragmentCheckChallengeBinding
+
+class CheckChallengeFragment : Fragment() {
+    private var _binding: FragmentCheckChallengeBinding? = null
+    private val binding get() = requireNotNull(_binding)
+    private val viewModel by viewModels<CheckChallengeViewModel>()
+    private val adapter by lazy { CheckEmojiAdapter { viewModel.checkedChanged(it) } }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentCheckChallengeBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(binding) {
+            lifecycleOwner = viewLifecycleOwner
+            viewModel = this@CheckChallengeFragment.viewModel
+            rvEmoji.adapter = adapter
+        }
+
+        viewModel.emojis.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckChallengeViewModel.kt
@@ -1,0 +1,33 @@
+package com.hrhn.presentation.ui.screen.addchallenge.check
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.hrhn.presentation.ui.screen.addchallenge.Emoji
+import com.hrhn.presentation.ui.screen.addchallenge.getEmojis
+
+class CheckChallengeViewModel : ViewModel() {
+    private val _selected = MutableLiveData<String?>()
+    val selected: LiveData<String?> get() = _selected
+
+    private val _emojis = MutableLiveData<List<Emoji>>(getEmojis())
+    val emojis: LiveData<List<Emoji>> get() = _emojis
+
+    fun checkedChanged(emoji: Emoji) {
+        if (emoji.isChecked) {
+            _emojis.value =
+                _emojis.value?.map {
+                    if (it.label == emoji.label) it.copy(isChecked = false)
+                    else it
+                }
+            _selected.value = null
+        } else {
+            _emojis.value = _emojis.value?.map {
+                if (it.label == emoji.label) it.copy(isChecked = true)
+                else if (it.isChecked) it.copy(isChecked = false)
+                else it
+            }
+            _selected.value = emoji.label
+        }
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckEmojiAdapter.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckEmojiAdapter.kt
@@ -1,0 +1,52 @@
+package com.hrhn.presentation.ui.screen.addchallenge.check
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil.ItemCallback
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.hrhn.databinding.ItemCheckableEmojiBinding
+import com.hrhn.presentation.ui.screen.addchallenge.Emoji
+
+class CheckEmojiAdapter(
+    private val onCheckedChange: (Emoji) -> Unit
+) : ListAdapter<Emoji, CheckEmojiAdapter.ViewHolder>(diffUtil) {
+    class ViewHolder(
+        private val binding: ItemCheckableEmojiBinding,
+        private val onCheckedChange: (Emoji) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(emoji: Emoji) {
+            binding.emoji = emoji
+            binding.ivEmoji.setBackgroundColor(Color.parseColor(emoji.color))
+            binding.root.setOnClickListener { onCheckedChange(emoji) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            ItemCheckableEmojiBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            ),
+            onCheckedChange
+        )
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val diffUtil = object : ItemCallback<Emoji>() {
+            override fun areItemsTheSame(oldItem: Emoji, newItem: Emoji): Boolean {
+                return oldItem.label == newItem.label
+            }
+
+            override fun areContentsTheSame(oldItem: Emoji, newItem: Emoji): Boolean {
+                return oldItem.isChecked == newItem.isChecked
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/util/BindingAdapters.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/BindingAdapters.kt
@@ -1,6 +1,8 @@
 package com.hrhn.presentation.util
 
+import android.view.View
 import android.widget.TextView
+import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -13,4 +15,9 @@ fun TextView.setDateString(date: LocalDateTime) {
 @BindingAdapter("android:dateWithYear")
 fun TextView.setDateWithYearString(date: LocalDateTime) {
     this.text = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+}
+
+@BindingAdapter("android:visibleIf")
+fun View.setVisible(boolean: Boolean) {
+    isVisible = boolean
 }

--- a/app/src/main/res/drawable/ic_check_24.xml
+++ b/app/src/main/res/drawable/ic_check_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/layout/activity_add_chanllenge.xml
+++ b/app/src/main/res/layout/activity_add_chanllenge.xml
@@ -1,9 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.ui.screen.addchallenge.AddChallengeActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".presentation.ui.screen.addchallenge.AddChallengeActivity">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tb_add_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:navigationIcon="@drawable/ic_arrow_back_24" />
+
+        <FrameLayout
+            android:id="@+id/fcv_add_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_check_challenge.xml
+++ b/app/src/main/res/layout/fragment_check_challenge.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.hrhn.presentation.ui.screen.addchallenge.check.CheckChallengeViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_title_check"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_default"
+            android:text="@string/title_check_last_challenge"
+            android:textAppearance="@style/HeaderText"
+            app:layout_constraintBottom_toTopOf="@+id/tv_last_challenge"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="spread" />
+
+        <TextView
+            android:id="@+id/tv_last_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_default"
+            android:background="@drawable/bg_challenge_card"
+            android:ellipsize="end"
+            android:gravity="center"
+            android:maxLength="100"
+            android:maxLines="3"
+            android:minHeight="100dp"
+            android:padding="@dimen/space_default"
+            android:text="무지무지 긴 텍스트 무지무지 긴 텍스트 무지무지 긴 텍스트 무지무지 긴 텍스트 무지무지 긴 텍스트 무지무지 긴 텍스트 무지무지 긴 텍스트 무지무지 긴 텍스트"
+            android:textColor="@color/gray_4a"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@+id/rv_emoji"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title_check" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_emoji"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_default"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toTopOf="@+id/btn_next"
+            app:layout_constraintTop_toBottomOf="@+id/tv_last_challenge"
+            app:spanCount="3"
+            tools:itemCount="6"
+            tools:listitem="@layout/item_checkable_emoji" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_next"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_margin="@dimen/space_default"
+            android:enabled="@{viewModel.selected!=null}"
+            android:text="@string/button_next"
+            app:cornerRadius="@dimen/radius_default"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/rv_emoji" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_today.xml
+++ b/app/src/main/res/layout/fragment_today.xml
@@ -51,7 +51,7 @@
         <androidx.constraintlayout.widget.Group
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:visibility="gone"
+            android:visibility="visible"
             app:constraint_referenced_ids="tv_no_challenge, btn_add_challenge" />
 
         <TextView
@@ -86,7 +86,7 @@
             android:text="영단어 100개 외우기"
             android:textAppearance="@style/HeaderText"
             android:textColor="@color/challenge_label"
-            android:visibility="visible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/view_background"
             app:layout_constraintEnd_toEndOf="@id/view_background"
             app:layout_constraintStart_toStartOf="@id/view_background"

--- a/app/src/main/res/layout/item_checkable_emoji.xml
+++ b/app/src/main/res/layout/item_checkable_emoji.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="emoji"
+            type="com.hrhn.presentation.ui.screen.addchallenge.Emoji" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/space_text">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_emoji"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="W,1:1"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/ShapeAppearance.HRHN.MediumComponent"
+            tools:background="@color/red_02" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:gravity="center"
+            android:text="@{emoji.label}"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_size_emoji_label_large"
+            app:layout_constraintDimensionRatio="W,1:1"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text=":D" />
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/checked"
+            android:src="@drawable/ic_check_24"
+            android:visibleIf="@{emoji.checked}"
+            app:contentPadding="@dimen/space_default"
+            app:layout_constraintDimensionRatio="W,1:1"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/ShapeAppearance.HRHN.MediumComponent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="clear">#00000000</color>
+    <color name="checked">#4D000000</color>
     <color name="gray_fb">#FFFBFBFB</color>
     <color name="gray_f6">#FFF6F6F6</color>
     <color name="gray_d4">#FFD4D4D4</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,4 +10,5 @@
     <dimen name="text_size_body2">16sp</dimen>
     <dimen name="text_size_caption">12sp</dimen>
     <dimen name="text_size_emoji_label">30sp</dimen>
+    <dimen name="text_size_emoji_label_large">50sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="setting">설정</string>
     <string name="message_no_challenge">오늘의 챌린지가 아직 없어요</string>
     <string name="button_add_challenge">챌린지 추가</string>
+    <string name="title_check_last_challenge">오늘을 시작하기 전,\n저번 챌린지를 평가하세요</string>
+    <string name="button_next">다음</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- close #6 

## 주요 구현 사항
- 지난 챌린지 평가 화면 레이아웃
- 리사이클러뷰 구현
- 선택된 아이템이 없는 경우 다음 버튼 비활성화
- 화면 크기 대응
   - 챌린지 라벨 텍스트뷰 `minHeight` 100으로 설정
   - vertical chain

## 스크린샷
<p>
<img src="https://user-images.githubusercontent.com/78132126/209258209-c8850d03-3df7-48b2-903c-689de75796d3.png" width="400"/>
<img src="https://user-images.githubusercontent.com/78132126/209258234-6bb38b96-e070-4a5d-8e4b-f106047910e3.png" width="400"/>
<img src="https://user-images.githubusercontent.com/78132126/209258812-e252f4fe-9296-4d24-8561-7c5c75814ea5.png" width="400"/>
<img src="https://user-images.githubusercontent.com/78132126/209258840-9f476a15-7361-45b8-9cc1-34c8796e5ad0.png" width="400"/>
</p>
