### PR TITLE
챌린지 등록

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
             android:exported="false" />
         <activity
             android:name=".presentation.ui.screen.addchallenge.AddChallengeActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".presentation.ui.screen.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
+++ b/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
@@ -19,4 +19,8 @@ class ChallengeRepositoryImpl : ChallengeRepository {
             Challenge(content = "영단어 100개 외우기", emoji = ":D", color = R.color.blue_01)
         )
     }
+
+    override fun addChallenge(challenge: Challenge): Result<Long> {
+        return Result.success(1)
+    }
 }

--- a/app/src/main/java/com/hrhn/domain/repository/ChallengeRepository.kt
+++ b/app/src/main/java/com/hrhn/domain/repository/ChallengeRepository.kt
@@ -4,4 +4,5 @@ import com.hrhn.domain.model.Challenge
 
 interface ChallengeRepository {
     fun getPastChallenges(): List<Challenge>
+    fun addChallenge(challenge: Challenge): Result<Long>
 }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/AddChallengeActivity.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/AddChallengeActivity.kt
@@ -7,7 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
 import com.hrhn.R
 import com.hrhn.databinding.ActivityAddChanllengeBinding
-import com.hrhn.presentation.ui.screen.addchallenge.check.CheckChallengeFragment
+import com.hrhn.presentation.ui.screen.addchallenge.add.AddChallengeFragment
 
 class AddChallengeActivity : AppCompatActivity() {
     private val binding by lazy { ActivityAddChanllengeBinding.inflate(layoutInflater) }
@@ -19,7 +19,7 @@ class AddChallengeActivity : AppCompatActivity() {
         // TODO last 아이템이 평가가 안되어있는지 체크
         if (savedInstanceState == null) {
             supportFragmentManager.commit {
-                add(R.id.fcv_add_challenge, CheckChallengeFragment())
+                add(R.id.fcv_add_challenge, AddChallengeFragment())
             }
         }
     }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/DoneFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/DoneFragment.kt
@@ -1,0 +1,31 @@
+package com.hrhn.presentation.ui.screen.addchallenge
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.hrhn.databinding.FragmentDoneBinding
+
+class DoneFragment : Fragment() {
+    private var _binding: FragmentDoneBinding? = null
+    private val binding get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDoneBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
@@ -5,11 +5,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.viewModels
+import com.hrhn.R
 import com.hrhn.databinding.FragmentAddChallengeBinding
+import com.hrhn.presentation.ui.screen.addchallenge.DoneFragment
+import com.hrhn.presentation.util.observeEvent
+import com.hrhn.presentation.util.showToast
 
 class AddChallengeFragment : Fragment() {
     private var _binding: FragmentAddChallengeBinding? = null
     private val binding get() = requireNotNull(_binding)
+    private val viewModel by viewModels<AddChallengeViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,6 +29,29 @@ class AddChallengeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initViews()
+        observeData()
+    }
+
+    private fun initViews() {
+        with(binding) {
+            lifecycleOwner = viewLifecycleOwner
+            vm = viewModel
+            etNewChallenge.requestFocus()
+        }
+    }
+
+    private fun observeData() {
+        with(viewModel) {
+            navigateEvent.observeEvent(viewLifecycleOwner) {
+                parentFragmentManager.commit {
+                    replace(R.id.fcv_add_challenge, DoneFragment())
+                }
+            }
+            message.observeEvent(viewLifecycleOwner) {
+                requireContext().showToast(it)
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeViewModel.kt
@@ -1,0 +1,38 @@
+package com.hrhn.presentation.ui.screen.addchallenge.add
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
+import androidx.lifecycle.ViewModel
+import com.hrhn.data.repository.ChallengeRepositoryImpl
+import com.hrhn.domain.model.Challenge
+import com.hrhn.domain.repository.ChallengeRepository
+import com.hrhn.presentation.util.Event
+import com.hrhn.presentation.util.emit
+
+class AddChallengeViewModel : ViewModel() {
+    private val repository: ChallengeRepository = ChallengeRepositoryImpl()
+
+    private val _navigateEvent = MutableLiveData<Event<Unit>>()
+    val navigateEvent: LiveData<Event<Unit>> get() = _navigateEvent
+
+    private val _message = MutableLiveData<Event<String>>()
+    val message: LiveData<Event<String>> get() = _message
+
+    val content = MutableLiveData<String>()
+    val nextEnabled: LiveData<Boolean> = Transformations.map(content) {
+        it.length in 10 until 100
+    }
+
+    fun saveNewChallenge() {
+        content.value?.let {
+            repository.addChallenge(Challenge(content = it))
+                .onSuccess {
+                    _navigateEvent.emit()
+                }
+                .onFailure { t ->
+                    _message.emit(t.message ?: "저장 실패")
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/util/Event.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/Event.kt
@@ -1,0 +1,32 @@
+package com.hrhn.presentation.util
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+
+open class Event<T>(value: T) {
+    var value = value
+        private set
+
+    private var isAlreadyHandled = false
+
+    fun isActive(): Boolean = if (isAlreadyHandled) {
+        false
+    } else {
+        isAlreadyHandled = true
+        true
+    }
+}
+
+fun <T> LiveData<Event<T>>.observeEvent(owner: LifecycleOwner, observer: Observer<T>) {
+    observe(owner) {
+        if (it.isActive()) {
+            observer.onChanged(it.value)
+        }
+    }
+}
+
+fun MutableLiveData<Event<Unit>>.emit() = postValue(Event(Unit))
+
+fun <T> MutableLiveData<Event<T>>.emit(value: T) = postValue(Event(value))

--- a/app/src/main/java/com/hrhn/presentation/util/ToastExt.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/ToastExt.kt
@@ -1,0 +1,8 @@
+package com.hrhn.presentation.util
+
+import android.content.Context
+import android.widget.Toast
+
+fun Context.showToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -1,13 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.hrhn.presentation.ui.screen.addchallenge.add.AddChallengeViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_default"
+            android:text="@string/message_new_challenge"
+            android:textAppearance="@style/HeaderText"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_editor_absoluteX="20dp" />
+
+        <EditText
+            android:id="@+id/et_new_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_margin="@dimen/space_large"
+            android:background="@drawable/bg_challenge_card"
+            android:gravity="center"
+            android:hint="@string/hint_for_challenge"
+            android:importantForAutofill="no"
+            android:inputType="textMultiLine"
+            android:padding="@dimen/space_large"
+            android:text="@={vm.content}"
+            android:textColor="@color/gray_4a"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/btn_next"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="@{vm.nextEnabled}"
+            android:onClick="@{() -> vm.saveNewChallenge()}"
+            android:paddingVertical="@dimen/space_default"
+            android:text="@string/button_next"
+            app:cornerRadius="0dp"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_done.xml
+++ b/app/src/main/res/layout/fragment_done.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_default"
+            android:text="@string/message_completely_added"
+            android:textAppearance="@style/HeaderText"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/space_default"
+            android:paddingVertical="@dimen/space_default"
+            android:text="@string/button_done"
+            app:cornerRadius="@dimen/radius_button"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="button_add_challenge">챌린지 추가</string>
     <string name="title_check_last_challenge">오늘을 시작하기 전,\n저번 챌린지를 평가하세요</string>
     <string name="button_next">다음</string>
+    <string name="message_new_challenge">오늘의 챌린지를\n작성해주세요</string>
+    <string name="hint_for_challenge">오늘의 다짐, 목표, 습관, 영어문장, 할일 혹은 무엇이든 좋아요</string>
+    <string name="message_completely_added">챌린지를 등록했어요!</string>
+    <string name="button_done">완료</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- close #9 

## 주요 구현 사항
- 기본 레이아웃
- 화면 진입 시 키보드 활성화
- 글자수 제한 (10 ~ 100자)
- 등록 성공 시 다음 화면으로 이동
- 실패 시 토스트 메시지 출력
- Event wrapper를 사용해 SingleLiveData 처리

## 스크린샷
<p>
<img src="https://user-images.githubusercontent.com/78132126/209279600-18f5feee-8e0c-4815-99a3-44ad298dace0.png" width="400"/>
<img src="https://user-images.githubusercontent.com/78132126/209279719-57807f7c-ef67-4869-9a19-b0a9ca16b273.png" width="400"/>
</p>
