### PR TITLE
[FEAT] 반복 알림 설정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".HRHNApplication"
         android:allowBackup="true"
@@ -20,10 +22,13 @@
         <activity
             android:name=".presentation.ui.screen.addchallenge.AddChallengeActivity"
             android:exported="false"
+            android:launchMode="singleTop"
+            android:parentActivityName=".presentation.ui.screen.MainActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".presentation.ui.screen.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".HRHNApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -11,7 +12,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.HRHN"
-        android:name=".HRHNApplication"
         tools:targetApi="31">
         <activity
             android:name=".presentation.ui.screen.setting.SettingActivity"
@@ -30,6 +30,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    </application>
 
+        <receiver android:name=".presentation.DailyAlarmReceiver" />
+    </application>
 </manifest>

--- a/app/src/main/java/com/hrhn/HRHNApplication.kt
+++ b/app/src/main/java/com/hrhn/HRHNApplication.kt
@@ -1,7 +1,24 @@
 package com.hrhn
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class HRHNApplication : Application()
+class HRHNApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            getString(R.string.notification_channel_id),
+            getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_HIGH
+        )
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/DailyAlarmReceiver.kt
+++ b/app/src/main/java/com/hrhn/presentation/DailyAlarmReceiver.kt
@@ -1,0 +1,34 @@
+package com.hrhn.presentation
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Context.NOTIFICATION_SERVICE
+import android.content.Intent
+import androidx.core.app.TaskStackBuilder
+import com.hrhn.R
+import com.hrhn.presentation.ui.screen.addchallenge.AddChallengeActivity
+import com.hrhn.presentation.util.NotificationUtil
+
+class DailyAlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val notificationManager =
+            context?.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = context.getString(R.string.notification_channel_id)
+        val addIntent = Intent(context, AddChallengeActivity::class.java)
+        val pendingIntent = TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(addIntent)
+            getPendingIntent(1, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+
+        val notification = NotificationUtil(channelId).createNotification(
+            context,
+            title = context.getString(R.string.notification_channel_name),
+            content = context.getString(R.string.notification_content),
+            pendingIntent = pendingIntent
+        )
+
+        notificationManager.notify(1, notification)
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/AddChallengeActivity.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/AddChallengeActivity.kt
@@ -42,7 +42,10 @@ class AddChallengeActivity : AppCompatActivity() {
 
     private fun observeData() {
         viewModel.message.observeEvent(this) {
-            this.showToast(it)
+            showToast(it)
+        }
+        viewModel.finishEvent.observeEvent(this) {
+            finish()
         }
     }
 

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/check/CheckChallengeViewModel.kt
@@ -13,6 +13,7 @@ import com.hrhn.presentation.util.emit
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,6 +23,9 @@ class CheckChallengeViewModel @Inject constructor(
     private val _needToUpdateLastChallengeEvent = MutableLiveData<Event<Boolean>>()
     val needToUpdateLastChallengeEvent: LiveData<Event<Boolean>>
         get() = _needToUpdateLastChallengeEvent
+
+    private val _finishEvent = MutableLiveData<Event<Unit>>()
+    val finishEvent: LiveData<Event<Unit>> get() = _finishEvent
 
     private val _navigateEvent = MutableLiveData<Event<Unit>>()
     val navigateEvent: LiveData<Event<Unit>> get() = _navigateEvent
@@ -44,7 +48,9 @@ class CheckChallengeViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             repository.getLastChallenge()
                 .onSuccess {
-                    if (it == null || it.emoji != null) {
+                    if (it != null && it.date.toLocalDate() == LocalDate.now()) {
+                        _finishEvent.emit()
+                    } else if (it == null || it.emoji != null) {
                         _needToUpdateLastChallengeEvent.emit(false)
                     } else {
                         _lastChallenge.postValue(it)

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/setting/SettingFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/setting/SettingFragment.kt
@@ -1,12 +1,34 @@
 package com.hrhn.presentation.ui.screen.setting
 
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import com.hrhn.R
+import com.hrhn.presentation.DailyAlarmReceiver
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class SettingFragment : PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private val alarmManager by lazy {
+        requireContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    }
+
+    private val pendingIntent by lazy {
+        PendingIntent.getBroadcast(
+            requireContext(),
+            1,
+            Intent(requireContext(), DailyAlarmReceiver::class.java),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
     }
@@ -22,6 +44,36 @@ class SettingFragment : PreferenceFragmentCompat(),
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        // TODO
+        val notificationOnOffKey = context?.getString(R.string.key_notification_on_off)
+        val hourKey = context?.getString(R.string.key_notification_hour)
+        val minuteKey = context?.getString(R.string.key_notification_minute)
+
+        if (key == notificationOnOffKey) {
+            with(sharedPreferences) {
+                if (getBoolean(notificationOnOffKey, false)) {
+                    val notificationTime = LocalDate.now().atTime(
+                        getInt(hourKey, 9),
+                        getInt(minuteKey, 0),
+                        0
+                    )
+                    setAlarm(notificationTime)
+                } else {
+                    cancelAlarm()
+                }
+            }
+        }
+    }
+
+    private fun setAlarm(time: LocalDateTime) {
+        alarmManager.setRepeating(
+            AlarmManager.RTC_WAKEUP,
+            time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            AlarmManager.INTERVAL_DAY,
+            pendingIntent
+        )
+    }
+
+    private fun cancelAlarm() {
+        alarmManager.cancel(pendingIntent)
     }
 }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/setting/SettingFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/setting/SettingFragment.kt
@@ -56,7 +56,12 @@ class SettingFragment : PreferenceFragmentCompat(),
                         getInt(minuteKey, 0),
                         0
                     )
-                    setAlarm(notificationTime)
+
+                    if (notificationTime.isBefore(LocalDateTime.now())) {
+                        setAlarm(notificationTime.plusDays(1))
+                    } else {
+                        setAlarm(notificationTime)
+                    }
                 } else {
                     cancelAlarm()
                 }
@@ -68,7 +73,7 @@ class SettingFragment : PreferenceFragmentCompat(),
         alarmManager.setRepeating(
             AlarmManager.RTC_WAKEUP,
             time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-            AlarmManager.INTERVAL_DAY,
+            1000 * 60,
             pendingIntent
         )
     }

--- a/app/src/main/java/com/hrhn/presentation/util/NotificationUtil.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/NotificationUtil.kt
@@ -1,0 +1,25 @@
+package com.hrhn.presentation.util
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.PRIORITY_HIGH
+import com.hrhn.R
+
+class NotificationUtil(private val channelId: String) {
+    fun createNotification(
+        context: Context,
+        title: String,
+        content: String,
+        pendingIntent: PendingIntent?
+    ): Notification {
+        return NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(content)
+            .setFullScreenIntent(pendingIntent, true)
+            .setPriority(PRIORITY_HIGH)
+            .build()
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/util/NotificationUtil.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/NotificationUtil.kt
@@ -4,7 +4,6 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationCompat.PRIORITY_HIGH
 import com.hrhn.R
 
 class NotificationUtil(private val channelId: String) {
@@ -18,8 +17,8 @@ class NotificationUtil(private val channelId: String) {
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle(title)
             .setContentText(content)
-            .setFullScreenIntent(pendingIntent, true)
-            .setPriority(PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
             .build()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_database_name">hrhn.db</string>
     <string name="notification_channel_id">하루하나</string>
     <string name="notification_channel_name">하루하나</string>
-    <string name="notification_title">오늘의 챌린지를 등록하세요</string>
+    <string name="notification_content">오늘의 챌린지를 등록하세요!</string>
     <string name="menu_title_today">오늘의 챌린지</string>
     <string name="menu_title_past_challenge">지난 챌린지</string>
     <string name="setting">설정</string>


### PR DESCRIPTION
## 관련 이슈
- close #7 

## 주요 구현 사항
- 노티피케이션 채널 설정
- 브로드캐스트 리시버 구현
- 반복 알람 기능 구현
- 오늘 날짜에 이미 등록된 챌린지가 있을 때, 알림을 클릭하는 경우 대응
   - `AddChallengeActivity`의 parent를 `MainActivity`로 두고, 오늘 날짜로 등록된 챌린지가 있는 경우 `MainActivity`를 보여주도록 함
- 현재 시점 이전으로 알람을 설정하는 경우 대응
   - `setRepeating()`은 밀리초 단위로 처음 알람 시각을 정한 후 주기만큼 반복하는 형태
   - 알람 시각을 현재 시점 이전으로 설정하는 경우, 현재 시간을 기준으로 주기마다 반복되는 문제 발생
   - 현재 시각과 비교하여 과거인 경우 다음날 해당 시각부터 알림을 설정하도록 함
   ```kotlin
    if (notificationTime.isBefore(LocalDateTime.now())) {
        setAlarm(notificationTime.plusDays(1))
    } else {
        setAlarm(notificationTime)
    }
   ```
- API 레벨 33 `POST_NOTIFICATION permission` 대응

