### PR TITLE
[FIX] 지난 챌린지 로직 수정

### DIFF
--- a/app/src/main/java/com/hrhn/presentation/ui/adapter/PastChallengeAdapter.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/adapter/PastChallengeAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hrhn.databinding.ItemChallengeBinding
 import com.hrhn.domain.model.Challenge
+import com.hrhn.presentation.util.Color.NONE
 
 class PastChallengeAdapter : ListAdapter<Challenge, PastChallengeAdapter.ViewHolder>(diffUtil) {
     class ViewHolder(private val binding: ItemChallengeBinding) :
@@ -15,9 +16,7 @@ class PastChallengeAdapter : ListAdapter<Challenge, PastChallengeAdapter.ViewHol
         fun bind(challenge: Challenge) {
             with(binding) {
                 this.challenge = challenge
-                challenge.emoji?.let {
-                    ivEmoji.setBackgroundColor(Color.parseColor(it.color))
-                }
+                ivEmoji.setBackgroundColor(Color.parseColor(challenge.emoji?.color ?: NONE))
             }
         }
     }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeFragment.kt
@@ -40,7 +40,11 @@ class PastChallengeFragment : Fragment() {
     }
 
     private fun initViews() {
-        binding.rvPastChallenge.adapter = adapter
+        with(binding) {
+            vm = viewModel
+            lifecycleOwner = viewLifecycleOwner
+            rvPastChallenge.adapter = adapter
+        }
     }
 
     private fun observeData() {

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.hrhn.databinding.FragmentPastChallengeBinding
-import com.hrhn.presentation.ui.adapter.PastChallengeAdapter
+import com.hrhn.presentation.ui.screen.main.past.adapter.PastChallengeAdapter
 import com.hrhn.presentation.util.observeEvent
 import com.hrhn.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeViewModel.kt
@@ -8,6 +8,7 @@ import com.hrhn.presentation.util.emit
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,7 +28,7 @@ class PastChallengeViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             repository.getChallenges()
                 .onSuccess { list ->
-                    _challenges.postValue(list.filter { it.emoji != null })
+                    _challenges.postValue(list.filter { it.date.toLocalDate() != LocalDate.now() })
                 }.onFailure { t ->
                     t.message?.let { _message.emit(it) }
                 }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/adapter/PastChallengeAdapter.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/adapter/PastChallengeAdapter.kt
@@ -1,4 +1,4 @@
-package com.hrhn.presentation.ui.adapter
+package com.hrhn.presentation.ui.screen.main.past.adapter
 
 import android.graphics.Color
 import android.view.LayoutInflater

--- a/app/src/main/java/com/hrhn/presentation/util/Constants.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/Constants.kt
@@ -1,0 +1,5 @@
+package com.hrhn.presentation.util
+
+object Color {
+    const val NONE = "#CCCCCC"
+}

--- a/app/src/main/res/layout/fragment_past_challenge.xml
+++ b/app/src/main/res/layout/fragment_past_challenge.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.hrhn.presentation.ui.screen.main.past.PastChallengeViewModel" />
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -33,11 +36,20 @@
             </com.google.android.material.appbar.CollapsingToolbarLayout>
         </com.google.android.material.appbar.AppBarLayout>
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/message_empty_challenges"
+            android:textColor="@color/gray_81"
+            android:visibleIf="@{vm.isEmpty()}" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_past_challenge"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/space_default"
+            android:visibleIf="@{!vm.isEmpty()}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
             tools:listitem="@layout/item_challenge" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="skyblue_01">#FFB0D9FF</color>
     <color name="blue_01">#FF97B4FE</color>
     <color name="purple_01">#FFE1BAFF</color>
+    <color name="none">#FFCCCCCC</color>
 
     <color name="label">@color/black</color>
     <color name="secondary_label">#993C3C43</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="setting">설정</string>
     <string name="message_no_challenge">오늘의 챌린지가 아직 없어요</string>
     <string name="button_add_challenge">챌린지 추가</string>
+    <string name="message_empty_challenges">아직 지난 챌린지가 없어요!</string>
     <string name="title_check_last_challenge">오늘을 시작하기 전,\n저번 챌린지를 평가하세요</string>
     <string name="button_next">다음</string>
     <string name="message_new_challenge">오늘의 챌린지를\n작성해주세요</string>


### PR DESCRIPTION
## 관련 이슈
- close #21 

## 주요 구현 사항
- 저장된 내역이 없는 경우, empty 텍스트 추가
- 리스트 필터링 조건 수정
   - 평가가 되지 않은 항목이 아닌 오늘 이전 데이터를 가져오도록 수정

## 스크린샷
<img src="https://user-images.githubusercontent.com/78132126/209670089-3d8d324e-3e07-421a-b42c-992b3ab33c6a.png" width="300"/>
