### PR TITLE
[FIX] 프래그먼트 전환 시 리스트 갱신 오류 해결 #26

### DIFF
--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
@@ -6,7 +6,9 @@ import com.hrhn.data.mapper.toModel
 import com.hrhn.domain.model.Challenge
 import java.time.LocalDateTime
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class ChallengeDataSourceImpl @Inject constructor(
     private val challengeDao: ChallengeDao
 ) : ChallengeDataSource {

--- a/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
+++ b/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
@@ -5,7 +5,9 @@ import com.hrhn.domain.model.Challenge
 import com.hrhn.domain.repository.ChallengeRepository
 import java.time.LocalDateTime
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class ChallengeRepositoryImpl @Inject constructor(
     private val challengeDataSource: ChallengeDataSource
 ) : ChallengeRepository {

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/MainActivity.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/MainActivity.kt
@@ -2,12 +2,15 @@ package com.hrhn.presentation.ui.screen
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
 import com.hrhn.R
 import com.hrhn.databinding.ActivityMainBinding
 import com.hrhn.presentation.ui.screen.main.past.PastChallengeFragment
+import com.hrhn.presentation.ui.screen.main.past.PastChallengeViewModel
 import com.hrhn.presentation.ui.screen.main.today.TodayFragment
+import com.hrhn.presentation.ui.screen.main.today.TodayViewModel
 import com.hrhn.presentation.ui.screen.setting.SettingActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -16,6 +19,8 @@ class MainActivity : AppCompatActivity() {
     private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
     private val todayFragment by lazy { TodayFragment() }
     private val pastChallengeFragment by lazy { PastChallengeFragment() }
+    private val todayViewModel by viewModels<TodayViewModel>()
+    private val pastChallengeViewModel by viewModels<PastChallengeViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/past/PastChallengeFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import com.hrhn.databinding.FragmentPastChallengeBinding
 import com.hrhn.presentation.ui.screen.main.past.adapter.PastChallengeAdapter
 import com.hrhn.presentation.util.observeEvent
@@ -16,7 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class PastChallengeFragment : Fragment() {
     private var _binding: FragmentPastChallengeBinding? = null
     private val binding get() = requireNotNull(_binding)
-    private val viewModel by viewModels<PastChallengeViewModel>()
+    private val viewModel by activityViewModels<PastChallengeViewModel>()
     private val adapter by lazy { PastChallengeAdapter() }
 
     override fun onCreateView(

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/today/TodayFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/today/TodayFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import com.hrhn.databinding.FragmentTodayBinding
 import com.hrhn.presentation.ui.screen.addchallenge.AddChallengeActivity
 import com.hrhn.presentation.util.observeEvent
@@ -17,7 +17,7 @@ import java.time.LocalDateTime
 class TodayFragment : Fragment() {
     private var _binding: FragmentTodayBinding? = null
     private val binding get() = requireNotNull(_binding)
-    private val viewModel by viewModels<TodayViewModel>()
+    private val viewModel by activityViewModels<TodayViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
## 관련 이슈
- close #26 

## 주요 구현 사항
- `replace()`를 통해 프래그먼트 전환 시 뷰모델 소멸
   - 뷰모델을 by lazy로 초기화 시 이전에 소멸된 뷰모델을 다시 참조하여 생기는 문제
   - `activityViewModels`로 뷰모델 유지하도록 하여 해결
