### PR TITLE
[FIX] 재부팅시 알람 재등록 및 정확도 개선

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:name=".HRHNApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
@@ -41,6 +42,13 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".presentation.BootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".presentation.DailyAlarmReceiver" />
     </application>
 </manifest>

--- a/app/src/main/java/com/hrhn/presentation/BootReceiver.kt
+++ b/app/src/main/java/com/hrhn/presentation/BootReceiver.kt
@@ -1,0 +1,18 @@
+package com.hrhn.presentation
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.hrhn.presentation.util.AlarmManagerUtil
+import com.hrhn.presentation.util.SharedPreferenceManager
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action.equals(Intent.ACTION_BOOT_COMPLETED)) {
+            val alarmManager = AlarmManagerUtil(context)
+            val sharedPreferenceManager = SharedPreferenceManager(context)
+            val time = sharedPreferenceManager.getAlarmTime()
+            alarmManager.setAlarm(time)
+        }
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/DailyAlarmReceiver.kt
+++ b/app/src/main/java/com/hrhn/presentation/DailyAlarmReceiver.kt
@@ -9,12 +9,20 @@ import android.content.Intent
 import androidx.core.app.TaskStackBuilder
 import com.hrhn.R
 import com.hrhn.presentation.ui.screen.addchallenge.AddChallengeActivity
+import com.hrhn.presentation.util.AlarmManagerUtil
 import com.hrhn.presentation.util.NotificationUtil
+import com.hrhn.presentation.util.SharedPreferenceManager
 
 class DailyAlarmReceiver : BroadcastReceiver() {
-    override fun onReceive(context: Context?, intent: Intent?) {
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        showNotification(context)
+        setNextAlarm(context)
+    }
+
+    private fun showNotification(context: Context) {
         val notificationManager =
-            context?.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         val channelId = context.getString(R.string.notification_channel_id)
         val addIntent = Intent(context, AddChallengeActivity::class.java)
         val pendingIntent = TaskStackBuilder.create(context).run {
@@ -30,5 +38,12 @@ class DailyAlarmReceiver : BroadcastReceiver() {
         )
 
         notificationManager.notify(1, notification)
+    }
+
+    private fun setNextAlarm(context: Context) {
+        val alarmManager = AlarmManagerUtil(context)
+        val sharedPreferenceManager = SharedPreferenceManager(context)
+        val time = sharedPreferenceManager.getAlarmTime()
+        alarmManager.setAlarm(time)
     }
 }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/onboarding/NotificationSettingFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/onboarding/NotificationSettingFragment.kt
@@ -72,7 +72,7 @@ class NotificationSettingFragment : Fragment() {
         }
         btnSetAlarm.setOnClickListener {
             if (hasNotificationPermission) {
-                alarmManager.setRepeatAlarm(sharedPreferenceManager.getAlarmTime())
+                alarmManager.setAlarm(sharedPreferenceManager.getAlarmTime())
                 sharedPreferenceManager.updateNotificationOnOff(true)
                 close()
             } else {

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/setting/SettingFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/setting/SettingFragment.kt
@@ -16,7 +16,10 @@ import com.hrhn.presentation.util.SharedPreferenceManager
 class SettingFragment : PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private val notificationOnOffKey by lazy { requireContext().getString(R.string.key_notification_on_off) }
+    private val keyNotificationOnOff by lazy { requireContext().getString(R.string.key_notification_on_off) }
+    private val keyHour by lazy { requireContext().getString(R.string.key_notification_hour) }
+    private val keyMinute by lazy { requireContext().getString(R.string.key_notification_minute) }
+
     private var hasNotificationPermission: Boolean = false
     private val permissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
@@ -27,7 +30,7 @@ class SettingFragment : PreferenceFragmentCompat(),
         }
 
     private fun resetOnOff() {
-        findPreference<SwitchPreferenceCompat>(notificationOnOffKey)?.isChecked = false
+        findPreference<SwitchPreferenceCompat>(keyNotificationOnOff)?.isChecked = false
     }
 
     private val alarmManager by lazy { AlarmManagerUtil(requireContext()) }
@@ -56,17 +59,21 @@ class SettingFragment : PreferenceFragmentCompat(),
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        if (key == notificationOnOffKey) {
+        if (key == keyNotificationOnOff || key == keyHour || key == keyMinute) {
             if (sharedPreferenceManager.isNotificationOn) {
-                if (hasNotificationPermission) {
-                    alarmManager.setRepeatAlarm(sharedPreferenceManager.getAlarmTime())
-                } else {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                    }
-                }
+                updateAlarm()
             } else {
                 alarmManager.cancelAlarm()
+            }
+        }
+    }
+
+    private fun updateAlarm() {
+        if (hasNotificationPermission) {
+            alarmManager.setAlarm(sharedPreferenceManager.getAlarmTime())
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
     }

--- a/app/src/main/java/com/hrhn/presentation/util/AlarmManagerUtil.kt
+++ b/app/src/main/java/com/hrhn/presentation/util/AlarmManagerUtil.kt
@@ -19,15 +19,14 @@ class AlarmManagerUtil(context: Context) {
         )
     }
 
-    fun setRepeatAlarm(time: LocalDateTime) {
-        alarmManager.setRepeating(
+    fun setAlarm(time: LocalDateTime) {
+        val startTime = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        alarmManager.setExactAndAllowWhileIdle(
             AlarmManager.RTC_WAKEUP,
-            time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-            AlarmManager.INTERVAL_DAY,
+            startTime,
             pendingIntent
         )
     }
 
     fun cancelAlarm() = alarmManager.cancel(pendingIntent)
-
 }


### PR DESCRIPTION
## 관련 이슈
- close #33 

## 주요 구현 사항
- 재부팅 시 알림이 사라지는 버그 수정
- 시간 정확도가 떨어지는 `setRepeating()` 대신 `setExact()` 사용하여 알림이 울릴 때마다 재설정하도록 수정
