### PR TITLE
[FEAT] 챌린지 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,12 @@
             android:parentActivityName=".presentation.ui.screen.MainActivity"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".presentation.ui.screen.edit.EditChallengeActivity"
+            android:exported="false"
+            android:parentActivityName=".presentation.ui.screen.MainActivity"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name=".presentation.ui.screen.addchallenge.AddChallengeActivity"
             android:exported="false"
             android:launchMode="singleTop"

--- a/app/src/main/java/com/hrhn/domain/model/Challenge.kt
+++ b/app/src/main/java/com/hrhn/domain/model/Challenge.kt
@@ -1,5 +1,6 @@
 package com.hrhn.domain.model
 
+import java.io.Serializable
 import java.time.LocalDateTime
 
 data class Challenge(
@@ -7,4 +8,4 @@ data class Challenge(
     val date: LocalDateTime = LocalDateTime.now(),
     val content: String = "",
     val emoji: Emoji? = null
-)
+) : Serializable

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeViewModel.kt
@@ -1,10 +1,6 @@
 package com.hrhn.presentation.ui.screen.addchallenge.add
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.hrhn.domain.model.Challenge
 import com.hrhn.domain.repository.ChallengeRepository
 import com.hrhn.presentation.util.Event
@@ -26,7 +22,7 @@ class AddChallengeViewModel @Inject constructor(
 
     val input = MutableLiveData<String>()
     val nextEnabled: LiveData<Boolean> = Transformations.map(input) {
-        it.length in 5 until 50
+        it.length in (2..50)
     }
 
     fun saveNewChallenge() {

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/edit/EditChallengeActivity.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/edit/EditChallengeActivity.kt
@@ -1,0 +1,66 @@
+package com.hrhn.presentation.ui.screen.edit
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.hrhn.databinding.ActivityEditChanllengeBinding
+import com.hrhn.domain.model.Challenge
+import com.hrhn.presentation.util.observeEvent
+import com.hrhn.presentation.util.showToast
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class EditChallengeActivity : AppCompatActivity() {
+    private val binding by lazy { ActivityEditChanllengeBinding.inflate(layoutInflater) }
+    private val viewModel by viewModels<EditChallengeViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        binding.lifecycleOwner = this
+        binding.vm = viewModel
+        initData()
+        initToolbar()
+        observeData()
+    }
+
+    private fun initData() {
+        val data = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getSerializableExtra(KEY, Challenge::class.java)
+        } else {
+            intent.getSerializableExtra(KEY) as Challenge
+        }
+        if (data != null) {
+            viewModel.setData(data)
+        }
+    }
+
+    private fun initToolbar() {
+        setSupportActionBar(binding.tbAddChallenge)
+        supportActionBar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            setDisplayShowTitleEnabled(false)
+        }
+    }
+
+    private fun observeData() {
+        viewModel.message.observeEvent(this) {
+            showToast(it)
+        }
+        viewModel.finishEvent.observeEvent(this) {
+            finish()
+        }
+    }
+
+    companion object {
+        private const val KEY = "challenge"
+
+        fun newIntent(context: Context, challenge: Challenge) =
+            Intent(context, EditChallengeActivity::class.java).apply {
+                putExtra(KEY, challenge)
+            }
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/edit/EditChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/edit/EditChallengeViewModel.kt
@@ -1,0 +1,50 @@
+package com.hrhn.presentation.ui.screen.edit
+
+import androidx.lifecycle.*
+import com.hrhn.domain.model.Challenge
+import com.hrhn.domain.repository.ChallengeRepository
+import com.hrhn.presentation.util.Event
+import com.hrhn.presentation.util.emit
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class EditChallengeViewModel @Inject constructor(
+    private val repository: ChallengeRepository
+) : ViewModel() {
+
+    private val _finishEvent = MutableLiveData<Event<Unit>>()
+    val finishEvent: LiveData<Event<Unit>> get() = _finishEvent
+
+    private val _message = MutableLiveData<Event<String>>()
+    val message: LiveData<Event<String>> get() = _message
+
+    val content = MutableLiveData<String>()
+    val nextEnabled: LiveData<Boolean> = Transformations.map(content) {
+        it.length in 5 until 50
+    }
+
+    private lateinit var challenge: Challenge
+
+    fun setData(challenge: Challenge) {
+        this.challenge = challenge
+        content.value = challenge.content
+    }
+
+    fun updateChallenge() {
+        if (this::challenge.isInitialized) {
+            val content = requireNotNull(content.value)
+            viewModelScope.launch(Dispatchers.IO) {
+                repository.updateChallenge(challenge.copy(content = content))
+                    .onSuccess {
+                        _finishEvent.emit()
+                    }
+                    .onFailure { t ->
+                        t.message?.let { _message.emit(it) }
+                    }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/edit/EditChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/edit/EditChallengeViewModel.kt
@@ -23,7 +23,7 @@ class EditChallengeViewModel @Inject constructor(
 
     val content = MutableLiveData<String>()
     val nextEnabled: LiveData<Boolean> = Transformations.map(content) {
-        it.length in 5 until 50
+        it.length in (2..50)
     }
 
     private lateinit var challenge: Challenge

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/today/TodayFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/today/TodayFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.hrhn.databinding.FragmentTodayBinding
 import com.hrhn.presentation.ui.screen.addchallenge.AddChallengeActivity
+import com.hrhn.presentation.ui.screen.edit.EditChallengeActivity
 import com.hrhn.presentation.util.observeEvent
 import com.hrhn.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,6 +55,9 @@ class TodayFragment : Fragment() {
             }
             message.observeEvent(viewLifecycleOwner) {
                 requireContext().showToast(it)
+            }
+            editEvent.observeEvent(viewLifecycleOwner) {
+                startActivity(EditChallengeActivity.newIntent(requireContext(), it))
             }
         }
     }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/main/today/TodayViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/main/today/TodayViewModel.kt
@@ -30,6 +30,9 @@ class TodayViewModel @Inject constructor(
     private val _addEvent = MutableLiveData<Event<Unit>>()
     val addEvent: LiveData<Event<Unit>> get() = _addEvent
 
+    private val _editEvent = MutableLiveData<Event<Challenge>>()
+    val editEvent: LiveData<Event<Challenge>> get() = _editEvent
+
     fun fetchData() {
         viewModelScope.launch(Dispatchers.IO) {
             repository.getChallengesWithPeriod(
@@ -50,4 +53,5 @@ class TodayViewModel @Inject constructor(
 
     fun addTodayChallenge() = _addEvent.emit()
 
+    fun editTodayChallenge() = _editEvent.emit(todayChallenge.value!!)
 }

--- a/app/src/main/res/layout/activity_edit_chanllenge.xml
+++ b/app/src/main/res/layout/activity_edit_chanllenge.xml
@@ -42,6 +42,7 @@
             android:hint="@string/hint_for_challenge"
             android:importantForAutofill="no"
             android:inputType="textMultiLine"
+            android:maxLength="50"
             android:paddingHorizontal="@dimen/space_large"
             android:paddingVertical="@dimen/space_default"
             android:text="@={vm.content}"

--- a/app/src/main/res/layout/activity_edit_chanllenge.xml
+++ b/app/src/main/res/layout/activity_edit_chanllenge.xml
@@ -81,7 +81,7 @@
             android:layout_height="wrap_content"
             android:enabled="@{vm.nextEnabled}"
             android:onClick="@{() -> vm.updateChallenge()}"
-            android:text="@string/button_next"
+            android:text="@string/button_done"
             app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_edit_chanllenge.xml
+++ b/app/src/main/res/layout/activity_edit_chanllenge.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.hrhn.presentation.ui.screen.edit.EditChallengeViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tb_add_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintTop_toTopOf="parent"
+            app:navigationIcon="@drawable/ic_arrow_back_24" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_default"
+            android:text="@string/message_edit_challenge"
+            android:textAppearance="@style/HeaderText"
+            app:layout_constraintTop_toBottomOf="@id/tb_add_challenge"
+            tools:layout_editor_absoluteX="20dp" />
+
+        <EditText
+            android:id="@+id/et_new_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="@dimen/space_large"
+            android:layout_marginVertical="@dimen/space_default"
+            android:background="@drawable/bg_challenge_card"
+            android:gravity="center"
+            android:hint="@string/hint_for_challenge"
+            android:importantForAutofill="no"
+            android:inputType="textMultiLine"
+            android:paddingHorizontal="@dimen/space_large"
+            android:paddingVertical="@dimen/space_default"
+            android:text="@={vm.content}"
+            android:textColor="@color/gray_4a"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/btn_next"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <TextView
+            android:id="@+id/tv_length"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:text="@{String.valueOf(vm.content.length())}"
+            android:textStyle="bold"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_max"
+            app:layout_constraintEnd_toStartOf="@id/tv_max"
+            tools:text="3" />
+
+        <TextView
+            android:id="@+id/tv_max"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/space_default"
+            android:gravity="end"
+            android:text="/50"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/et_new_challenge"
+            app:layout_constraintEnd_toEndOf="@id/et_new_challenge" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_next"
+            style="@style/LargeButton.FillMaxWidth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="@{vm.nextEnabled}"
+            android:onClick="@{() -> vm.updateChallenge()}"
+            android:text="@string/button_next"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -35,6 +35,7 @@
             android:hint="@string/hint_for_challenge"
             android:importantForAutofill="no"
             android:inputType="textMultiLine"
+            android:maxLength="50"
             android:paddingHorizontal="@dimen/space_large"
             android:paddingVertical="@dimen/space_default"
             android:text="@={vm.input}"

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -74,7 +74,7 @@
             android:layout_height="wrap_content"
             android:enabled="@{vm.nextEnabled}"
             android:onClick="@{() -> vm.saveNewChallenge()}"
-            android:text="@string/button_next"
+            android:text="@string/button_done"
             app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_today.xml
+++ b/app/src/main/res/layout/fragment_today.xml
@@ -50,6 +50,8 @@
             android:layout_marginTop="@dimen/space_default"
             android:layout_marginBottom="@dimen/space_large"
             android:background="@drawable/bg_challenge_card"
+            android:clickable="@{!vm.isEmpty()}"
+            android:onClick="@{() -> vm.editTodayChallenge()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="title_check_last_challenge">오늘을 시작하기 전,\n저번 챌린지를 평가하세요</string>
     <string name="button_next">다음</string>
     <string name="message_new_challenge">오늘의 챌린지를\n작성해주세요</string>
+    <string name="message_edit_challenge">오늘의 챌린지를\n수정해주세요</string>
     <string name="hint_for_challenge">오늘의 다짐, 목표, 습관, 영어문장, 할일 혹은 무엇이든 좋아요</string>
     <string name="message_completely_added">챌린지를 등록했어요!</string>
     <string name="button_done">완료</string>
@@ -53,4 +54,5 @@
     <string name="key_notification_on_off">key_notification_on_off</string>
     <string name="key_notification_hour">key_notification_hour</string>
     <string name="key_notification_minute">key_notification_minute</string>
+    <string name="key_challenge_data">key_challenge_data</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- close #38 

## 주요 구현 사항
- 오늘의 챌린지가 등록되어 있는 경우, 카드를 클릭하면 수정화면으로 이동

    https://user-images.githubusercontent.com/78132126/210088349-e8a12ecd-8440-4429-8dbc-2b151ecf8f9d.mp4


## 메모
- `getSerializableExtra()`가 deprecate 되었다는 소식...
